### PR TITLE
Create GitHub action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: 'Test'
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: ~
+
+jobs:
+  build:
+    name: Test action build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: False
+      matrix:
+        architecture:
+          - aarch64
+          - amd64
+          - armv7
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+
+    - name: Test ${{ matrix.architecture }} builder action
+      uses: ./ # This is self-refrencing
+      with:
+        args: |
+          --test \
+          --${{ matrix.architecture }} \
+          --target /data \
+          --generic ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -43,3 +43,63 @@ docker run --rm --privileged -v ~/.docker:/root/.docker -v /var/run/docker.sock:
 ```bash
 $ docker run --rm --privileged homeassistant/amd64-builder --help
 ```
+
+## GitHub Action
+
+You can use this repository as a GitHub action to test and/or publish your builds.
+
+Use the `with.args` key to pass in arguments to the builder, to see what arguments are supported you can run the [help](#help) or look in the [builder.sh file](./builder.sh)
+
+### Test action example
+
+```yaml
+name: 'Test'
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Test build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+    - name: Test build
+      uses: home-assistant/hassio-builder@master
+      with:
+        args: |
+          --test \
+          --all \
+          --target /data \
+          --docker-hub userspace-name
+```
+
+### Publish action example
+
+```yaml
+name: 'Publish'
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pubnlish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Publish
+      uses: home-assistant/hassio-builder@master
+      with:
+        args: |
+          --all \
+          --target /data \
+          --docker-hub userspace-name
+```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ on:
     types: [published]
 
 jobs:
-  pubnlish:
+  publish:
     name: Publish
     runs-on: ubuntu-latest
     steps:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,25 @@
+name: 'Home Assistant builder'
+description: 'Multi-purpose cross-compile docker builder'
+inputs:
+  args:
+    description: 'Arguments passed to the builder'
+    required: true
+    default: '--help'
+runs:
+  using: "composite"
+  steps: 
+    - shell: bash
+      id: build
+      run: |
+        docker run --rm --privileged \
+            -v /var/run/docker.sock:/var/run/docker.sock:ro \
+            -v ~/.docker:/root/.docker \
+            -v ${{ github.workspace }}:/data \
+            homeassistant/amd64-builder \
+            ${{ inputs.args }}
+    - shell: bash
+      id: verify
+      run: docker images
+branding:
+  icon: 'home'  
+  color: 'blue'

--- a/builder.sh
+++ b/builder.sh
@@ -299,8 +299,12 @@ function run_build() {
                     bashio::log.info "Upload succeeded on attempt #${j}"
                     break
                 fi
-                bashio::log.warning "Upload failed on attempt #${j}"
-                sleep 30
+                if [[ "${j}" == "3" ]]; then
+                    bashio::exit.nok "Upload failed on attempt #${j}"
+                else
+                    bashio::log.warning "Upload failed on attempt #${j}"
+                    sleep 30
+                fi
             done
         done
     fi


### PR DESCRIPTION
This PR makes this repository become a GitHub action so other repositories can use the builder to test and publish their stuff.

As an example, I have tested my fork of this, and a fork of the supervisor repo and this are the results:

- [action file](https://github.com/ludeeus/supervisor/blob/action/.github/workflows/build.yml)
- [action log](https://github.com/ludeeus/supervisor/actions/runs/320443048)
- [dockerhub](https://hub.docker.com/layers/ludeeus/amd64-hassio-supervisor/52216a6c198fe1596c20f737ca388aa5174fc840/images/sha256-594792f9b2db9ec39493c32dd1f8159c1b8a0cc4b0bc20f56fac39e5c43c64f9?context=repo)

In addition to this, I've changed the `builder.sh` file so it now exits after 3 attempts resulting in a failed action.