### PR TITLE
Migrate to tonistiigi/binfmt

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -747,7 +747,9 @@ function init_crosscompile() {
     fi
 
     bashio::log.info "Setup crosscompiling feature"
-    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes \
+    docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-* \
+        > /dev/null 2>&1 || bashio::log.warning "Can't remove old qemu binfmt"
+    docker run --rm --privileged tonistiigi/binfmt --install all \
         > /dev/null 2>&1 || bashio::log.warning "Can't enable crosscompiling feature"
 }
 


### PR DESCRIPTION
Our current qemu multiarch we use for binfmt binaries, currently has issues:

https://github.com/multiarch/qemu-user-static/issues/212

It hasn't been updated in the last 2 years.

tonistiigi/binfmt recently released a version with QEMU 9 in it, which does address the issue. This is the binfmt that is, for example, also used by Dockers QEMU setup action.

