### PR TITLE
actions/publish: use dotslash self-reference

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish ${{ matrix.architecture }} builder
-        uses: home-assistant/builder@2025.09.0
+        uses: ./
         with:
           args: |
             --${{ matrix.architecture }} \


### PR DESCRIPTION
Use dotslash self-reference to build builder with itself. This resolves one of the friction points for being able to clone the repo somewhere else on GitHub and run the actions outside of home-assistant org.