### PR TITLE
action: use context repository_owner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "Define the builder image archictecture (default: amd64)"
     required: false
     default: "amd64"
+  namespace:
+    description: "Define alternative namespace to use when image not found at this repository"
+    required: true
+    default: "home-assistant"
 runs:
   using: "composite"
   steps:
@@ -31,18 +35,28 @@ runs:
         echo "version=${input}" >> "$GITHUB_OUTPUT"
 
     - shell: bash
+      id: namespace
+      run: |
+        if docker manifest inspect ghcr.io/${{ github.repository_owner }}/${{ inputs.image }}-builder:${{ steps.version.outputs.version }}
+        then
+          echo "namespace=${{ github.repository_owner }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "namespace=${{ inputs.namespace }}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - shell: bash
       if: ${{ inputs.pull == 'true' }}
       run: |
-        docker pull ghcr.io/home-assistant/${{ inputs.image }}-builder:${{ steps.version.outputs.version }}
+        docker pull ghcr.io/${{ steps.namespace.outputs.namespace }}/${{ inputs.image }}-builder:${{ steps.version.outputs.version }}
         cosign verify \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity-regexp https://github.com/home-assistant/builder/.* \
-          ghcr.io/home-assistant/${{ inputs.image }}-builder:${{ steps.version.outputs.version }}
+          --certificate-identity-regexp https://github.com/${{ steps.namespace.outputs.namespace }}/builder/.* \
+          ghcr.io/${{ steps.namespace.outputs.namespace }}/${{ inputs.image }}-builder:${{ steps.version.outputs.version }}
 
     - shell: bash
       id: builder
       run: |
-        builder=$(docker images ghcr.io/home-assistant/${{ inputs.image }}-builder:${{ steps.version.outputs.version }} -q)
+        builder=$(docker images ghcr.io/${{ steps.namespace.outputs.namespace }}/${{ inputs.image }}-builder:${{ steps.version.outputs.version }} -q)
         echo "id=$builder" >> "$GITHUB_OUTPUT"
 
     - shell: bash
@@ -59,7 +73,7 @@ runs:
             -v ~/.docker:/root/.docker \
             -v ${{ github.workspace }}:/data \
             --env-file "${{ github.action_path }}/env_file" \
-            ghcr.io/home-assistant/${{ inputs.image }}-builder:${{ steps.version.outputs.version }} \
+            ghcr.io/${{ steps.namespace.outputs.namespace }}/${{ inputs.image }}-builder:${{ steps.version.outputs.version }} \
             ${{ inputs.args }}
 
         sudo sysctl kernel.randomize_va_space=2


### PR DESCRIPTION
Use context github.repository_owner instead of hard-coded "home-assistant" namespace in action.yml . This resolves one of the friction points for being able to clone the repo somewhere else on GitHub and run the actions outside of home-assistant org.

Edit: Have updated this to take a slightly different approach where a "namespace" output is defined and is conditionally dependent on when github.repository_owner is valid for run and pull of image to build from. The use of a hard-coded value "home-assistant" is now configurable.