### PR TITLE
Use default cosign-release for pinned cosign-installer version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,6 @@ runs:
 
     - name: Install Cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-      with:
-        cosign-release: "v2.5.3"
 
     - shell: bash
       id: version

--- a/actions/build-image/action.yml
+++ b/actions/build-image/action.yml
@@ -108,8 +108,6 @@ runs:
     - name: Install Cosign
       if: inputs.cosign == 'true' || inputs.cosign-base-verify != ''
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-      with:
-        cosign-release: "v2.5.3"
 
     - name: Verify cache image ${{ inputs.image }}:${{ inputs.cache-image-tag }}
       if: inputs.cosign == 'true'

--- a/actions/publish-multi-arch-manifest/action.yml
+++ b/actions/publish-multi-arch-manifest/action.yml
@@ -50,8 +50,6 @@ runs:
     - name: Install Cosign
       if: inputs.cosign == 'true'
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-      with:
-        cosign-release: "v2.5.3"
 
     - name: Create multi-arch manifest and sign it
       shell: bash


### PR DESCRIPTION
Relax cosign-release to default value for sigstore/cosign-installer@v4.1.1

Version bump side-effect cosign v3.0.5 and going forward remains constrained by sigstore/cosign-installer itself having a policy of "The used Cosign version only changes when cosign-installer is upgraded"

Resolves: home-assistant/builder#296