### PR TITLE
workflows: use dotslash self-reference on test Build the builder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build the builder
-        uses: home-assistant/builder@6cb4fd3d1338b6e22d0958a4bcb53e0965ea63b4 # 2026.02.1
+        uses: ./
         with:
           args: |
             --test \


### PR DESCRIPTION
Use dotslash self-reference to test 'Build the builder' with itself. This resolves one of the friction points for being able to clone the repository somewhere else on GitHub and run the actions outside of home-assistant org. Similar in scope to previous accepted PR home-assistant/builder#258